### PR TITLE
Units no longer set by protocol

### DIFF
--- a/edwardsTicApp/Db/edwardsTicErrorsUnits.substitutions
+++ b/edwardsTicApp/Db/edwardsTicErrorsUnits.substitutions
@@ -34,11 +34,3 @@ file "$(UTILITIES)/db/error_setter.template" {
     {"\$(P)", "GAUGE3:PRESSURE", "GAUGE3:UNIT"}
     {"\$(P)", "GAUGE3:PRESSURE", "GAUGE3:PRI"}
 }
-
-file "$(UTILITIES)/db/unit_setter.template" {
-  pattern {P, FROM, TO}
-
-  {"\$(P)", "GAUGE1:UNIT", "GAUGE1:PRESSURE"}
-  {"\$(P)", "GAUGE2:UNIT", "GAUGE2:PRESSURE"}
-  {"\$(P)", "GAUGE3:UNIT", "GAUGE3:PRESSURE"}
-}

--- a/edwardsTicApp/Db/edwardsTicGauge.db
+++ b/edwardsTicApp/Db/edwardsTicGauge.db
@@ -11,22 +11,36 @@
 ################################################################################
 # P - Pressure
 #
-record(ai, "$(P)GAUGE$(GAUGE):PRESSURE")
+record(ai, "$(P)GAUGE$(GAUGE):PRESSURE:RAW")
 {
-    field(DESC, "Gauge $(GAUGE) Pressure")
+    field(DESC, "Gauge $(GAUGE) Pa pressure")
     field(DTYP, "stream")
     field(INP,  "@edwardsTic.proto get_g$(GAUGE)_p($(P)GAUGE$(GAUGE):) $(PORT)")
     field(SCAN, "1 second")
 
-    field(EGU, "")
+    field(EGU, "Pa")
+
+    info(archive, "VAL")
+}
+
+record(calc, "$(P)GAUGE$(GAUGE):PRESSURE")
+{
+    field(DESC, "Gauge $(GAUGE) Pressure")
+    field(INPA, "$(P)GAUGE$(GAUGE):PRESSURE:RAW CP MS")
+    field(CALC, "A/100.0")
+    field(PREC, "2")
+
+    field(EGU, "mbar")
 
     info(archive, "VAL")
     info(INTEREST, "HIGH")
 
     info(alarm, "EDTIC")
 }
+
 record(mbbi, "$(P)GAUGE$(GAUGE):UNIT")
 {
+    # These units are not used at ISIS. They are assumed to be Pa.
     field(DESC, "Gauge $(GAUGE) Units")
     field(DTYP, "Raw Soft Channel")
     field(ZRVL, "59")


### PR DESCRIPTION
## Description of work
Adds a calc record to convert the input gauge pressure reading in Pa to mbar (mbar = Pa/100)
Removes the unit setter, as we are now assuming readings in Pa

## Ticket
https://github.com/ISISComputingGroup/IBEX/issues/4701

## Acceptance criteria
- [ ] Pressure is correctly read back in mbar
- [ ] Unit setter no longer copies the units from the `:UNIT` PV to `:PRESSURE`